### PR TITLE
Version file syntax fixes

### DIFF
--- a/KerbalAcademy.version
+++ b/KerbalAcademy.version
@@ -1,8 +1,8 @@
 {
     "NAME"     : "Contract Pack: Kerbal Academy",
-    "URL"      : "https://github.com/Mark-Kerbin/Kerbal-Academy-Contract-Pack/blob/master/KerbalAcademy.version"
-    "DOWNLOAD" : "https://spacedock.info/mod/1819/Kerbal%20Academy%20Contract%20Pack/download/1.2.0"
-    "GITHUB" : "https://github.com/Mark-Kerbin/Kerbal-Academy-Contract-Pack/releases"
+    "URL"      : "https://github.com/Mark-Kerbin/Kerbal-Academy-Contract-Pack/blob/master/KerbalAcademy.version",
+    "DOWNLOAD" : "https://spacedock.info/mod/1819/Kerbal%20Academy%20Contract%20Pack/download/1.2.0",
+    "GITHUB" :
     {
         "USERNAME" : "Mark-Kerbin"
         "REPOSITORY" : "Kerbal-Academy-Contract-Pack"


### PR DESCRIPTION
The version file in this mod's latest release has some syntax errors. Some commas are missing, and the "GITHUB" property has both a string and an object following it. This prevents this release from being indexed by the NetKAN bot.

This pull request fixes these problems.